### PR TITLE
Proof of concept for buyer wait page w/task

### DIFF
--- a/dimension/migrations/0001_initial.py
+++ b/dimension/migrations/0001_initial.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import otree.db.models
+import otree_save_the_change.mixins
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('otree', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Group',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('_is_missing_players', otree.db.models.BooleanField(default=False, db_index=True, choices=[(True, 'Yes'), (False, 'No')])),
+                ('id_in_subsession', otree.db.models.PositiveIntegerField(null=True, db_index=True)),
+                ('round_number', otree.db.models.PositiveIntegerField(null=True, db_index=True)),
+                ('session', otree.db.models.ForeignKey(related_name='dimension_group', to='otree.Session')),
+            ],
+            options={
+                'db_table': 'dimension_group',
+            },
+            bases=(otree_save_the_change.mixins.SaveTheChange, models.Model),
+        ),
+        migrations.CreateModel(
+            name='Player',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('_index_in_game_pages', otree.db.models.PositiveIntegerField(default=0, null=True)),
+                ('round_number', otree.db.models.PositiveIntegerField(null=True, db_index=True)),
+                ('id_in_group', otree.db.models.PositiveIntegerField(null=True, db_index=True)),
+                ('payoff', otree.db.models.CurrencyField(null=True, max_digits=12)),
+                ('role_int', otree.db.models.PositiveIntegerField(null=True, blank=True)),
+                ('seller_price0', otree.db.models.CurrencyField(null=True, max_digits=12, blank=True)),
+                ('seller_price1', otree.db.models.CurrencyField(null=True, max_digits=12, blank=True)),
+                ('seller_price2', otree.db.models.CurrencyField(null=True, max_digits=12, blank=True)),
+                ('seller_price3', otree.db.models.CurrencyField(null=True, max_digits=12, blank=True)),
+                ('seller_price4', otree.db.models.CurrencyField(null=True, max_digits=12, blank=True)),
+                ('seller_price5', otree.db.models.CurrencyField(null=True, max_digits=12, blank=True)),
+                ('seller_price6', otree.db.models.CurrencyField(null=True, max_digits=12, blank=True)),
+                ('seller_price7', otree.db.models.CurrencyField(null=True, max_digits=12, blank=True)),
+                ('seller_total_price', otree.db.models.CurrencyField(null=True, max_digits=12, blank=True)),
+                ('sales', otree.db.models.PositiveIntegerField(null=True, blank=True)),
+                ('earnings', otree.db.models.PositiveIntegerField(null=True, blank=True)),
+                ('buyer_choice', otree.db.models.PositiveIntegerField(blank=True, null=True, verbose_name=b'And you will', choices=[(0, b'Buy from seller 0'), (1, b'Buy from seller 1')])),
+                ('price_paid', otree.db.models.PositiveIntegerField(null=True, blank=True)),
+                ('identifier', otree.db.models.PositiveIntegerField(null=True, blank=True)),
+                ('clicks', otree.db.models.PositiveIntegerField(default=0, null=True)),
+                ('group', otree.db.models.ForeignKey(to='dimension.Group', null=True)),
+                ('participant', otree.db.models.ForeignKey(related_name='dimension_player', to='otree.Participant')),
+                ('session', otree.db.models.ForeignKey(related_name='dimension_player', to='otree.Session')),
+            ],
+            options={
+                'db_table': 'dimension_player',
+            },
+            bases=(otree_save_the_change.mixins.SaveTheChange, models.Model),
+        ),
+        migrations.CreateModel(
+            name='Subsession',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('round_number', otree.db.models.PositiveIntegerField(null=True, db_index=True)),
+                ('num_prices', otree.db.models.PositiveIntegerField(null=True)),
+                ('sellers_per_group', otree.db.models.PositiveIntegerField(null=True)),
+                ('buyers_per_group', otree.db.models.PositiveIntegerField(null=True)),
+                ('session', otree.db.models.ForeignKey(related_name='dimension_subsession', to='otree.Session', null=True)),
+            ],
+            options={
+                'db_table': 'dimension_subsession',
+            },
+            bases=(otree_save_the_change.mixins.SaveTheChange, models.Model),
+        ),
+        migrations.AddField(
+            model_name='player',
+            name='subsession',
+            field=otree.db.models.ForeignKey(to='dimension.Subsession'),
+        ),
+        migrations.AddField(
+            model_name='group',
+            name='subsession',
+            field=otree.db.models.ForeignKey(to='dimension.Subsession'),
+        ),
+    ]

--- a/dimension/models.py
+++ b/dimension/models.py
@@ -173,6 +173,9 @@ class Player(BasePlayer):
     # Both the buyers and sellers will need a randomly assigned identifier in
     # order to reference each anonymized player type
     identifier = models.PositiveIntegerField(null = True, blank = True)
+
+    # Number of clicks on the buyer wait page.
+    clicks = models.PositiveIntegerField(default=0)
     
     def role(self):
         return {1:'seller', 2:'buyer'}[self.role_int]
@@ -232,4 +235,8 @@ class Player(BasePlayer):
                     player.payoff = player.earnings
             else:
                 player.payoff = 0
-                
+
+    def add_click(self):
+        self.clicks = self.clicks + 1
+        self.save()
+        return self.clicks

--- a/dimension/templates/dimension/BuyerWaitPage.html
+++ b/dimension/templates/dimension/BuyerWaitPage.html
@@ -1,0 +1,12 @@
+{% extends "global/Base.html" %}
+{% load staticfiles otree_tags %}
+
+{% block title %}
+Buyer Wait Page
+{% endblock %}
+
+{% block content %}
+<div>
+  <input type="button" value="Click me" />
+</div>
+{% endblock %}

--- a/dimension/templates/dimension/BuyerWaitPage.html
+++ b/dimension/templates/dimension/BuyerWaitPage.html
@@ -7,6 +7,15 @@ Buyer Wait Page
 
 {% block content %}
 <div>
-  <input type="button" value="Click me" />
+  <input type="button" value="Click me" id="click-button" />
+  <div id="clicks"></div>
 </div>
+<script type="text/javascript">
+$('#click-button').on('click', function() {
+  $.get('{% url "click" %}?player_id={{ player.pk }}', function(response) {
+    $('#clicks').text(response)
+    console.log(response);
+  });
+});
+</script>
 {% endblock %}

--- a/dimension/views.py
+++ b/dimension/views.py
@@ -3,6 +3,9 @@ from __future__ import division
 from . import models
 from ._builtin import Page, WaitPage
 
+from django.http import HttpResponse
+from django.views.generic import View
+
 
 def vars_for_all_templates(self):
     return {'instructions': 'dimension/Instructions.html'}
@@ -176,3 +179,16 @@ page_sequence = [
 # RiskQ4
 # Gender
 # EndExperiment
+
+
+class ClickView(View):
+    def get(self, request):
+        player_id = request.GET.get('player_id')
+
+        try:
+            player = models.Player.objects.get(pk=player_id)
+        except models.Player.DoesNotExist:
+            return HttpResponse('something went wrong')
+
+        clicks = player.add_click()
+        return HttpResponse('{} click(s)'.format(clicks))

--- a/dimension/views.py
+++ b/dimension/views.py
@@ -122,7 +122,7 @@ class SetPricesWaitPage(WaitPage):
     pass
 
 class BuyerWaitPage(WaitPage):
-    pass
+    template_name = 'dimension/BuyerWaitPage.html'
 
     
 class RoundSummary(Page):

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,1 +1,1 @@
-otree-core==0.4.47
+otree-core==0.7.7

--- a/settings.py
+++ b/settings.py
@@ -129,3 +129,5 @@ SESSION_CONFIGS = [
 # anything you put after the below line will override
 # oTree's default settings. Use with caution.
 otree.settings.augment_settings(globals())
+
+ROOT_URLCONF = 'urls'

--- a/urls.py
+++ b/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+from otree.default_urls import urlpatterns
+
+from dimension.views import ClickView
+
+
+urlpatterns.append(url(r'^click/$', ClickView.as_view(), name='click'))


### PR DESCRIPTION
This PR customizes the buyer wait page (the page buyers wait at until all sellers have entered their prices) with a simple task: click a button over and over to increment a number. The total number of clicks is stored on the `Player` model as `Player.clicks`.

Ugly but functional:
![image](https://cloud.githubusercontent.com/assets/654645/17038529/1bb405ee-4f64-11e6-9f01-a3f7998969e7.png)
